### PR TITLE
Ee 1122: Added amount-specification

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5503
+}

--- a/docs.json
+++ b/docs.json
@@ -20,6 +20,7 @@
               "guides/introductions/platform-overview",
               "guides/introductions/authorization",
               "guides/introductions/endpoint-specification",
+              "guides/introductions/amount-specification",
               "guides/introductions/environments",
               "guides/introductions/wallets",
               "guides/introductions/testing",

--- a/guides/collections/direct-charge/examples.mdx
+++ b/guides/collections/direct-charge/examples.mdx
@@ -1,4 +1,6 @@
-# Direct Charge Example Payload
+---
+title: Direct Charge Example Payload
+---
 
 A Basic Mobile Money Direct Charge Payload will look like this:
 ```json

--- a/guides/disbursements/authorization-mode.mdx
+++ b/guides/disbursements/authorization-mode.mdx
@@ -1,4 +1,7 @@
-# Authorization Mode
+---
+title: Authorization Mode
+---
+
 Payfonte supports 2 types of authorization for disbursement/payout processes to ensure secure transactions. This documentation provides detailed information on the implementation and usage of these authorization methods.
 
 ## Authorization Methods
@@ -22,11 +25,10 @@ PS: you can only do this once. you will have to reach out to support if you want
 
 Every API request must have the PIN field.
 
-```jsx JSON
+```jsonc
 {
-  ....
-  "pin":"XXXX",
-  ....
+  // ... other fields
+  "pin": "XXXX"
 }
 ```
 
@@ -49,6 +51,6 @@ Navigate to the page in the `Disbursements -> Settings` section of the dashboard
 ### Best Practice
 We advise the following should be done when we call your endpoint
 
-- Validate the payload comes from us by calculating the hash and verifying it. Examples can be found [in the webhook page](/guides/collections/webhook.md)
+- Validate the payload comes from us by calculating the hash and verifying it. Examples can be found [in the webhook page](/guides/collections/webhook)
 - Validate the amount in the payload matches what you sent
 - Validate the customer has enough funds in their wallet with you to carry out the transaction if this is a B2C

--- a/guides/introductions/amount-specification.mdx
+++ b/guides/introductions/amount-specification.mdx
@@ -1,0 +1,78 @@
+# Amount Specification
+This page explains how to represent monetary values when interacting with Payfonte APIs. To keep calculations precise and consistent across currencies and providers, **all amounts must be sent in the smallest (least) denomination** of the currency.
+
+For example, instead of sending `100.50` naira, you send `10050` kobo.
+
+## Why least denomination?
+
+- **Accuracy**
+  Working in the smallest unit avoids floating‑point rounding issues (e.g. `0.1 + 0.2 ≠ 0.3` in many languages).
+- **Consistency across endpoints**
+  All Payfonte endpoints that accept amounts (collections, disbursements, refunds, fees, etc.) expect the same format.
+- **Provider alignment**
+  Underlying payment processors, banks and wallets generally operate on integer minor units (kobo, cents, pesewas, etc.).
+
+## General rule
+
+Send **integer values only**, representing the amount in the currency’s smallest unit.
+
+- **NGN (Nigerian Naira)** → kobo
+- **GHS (Ghanaian Cedi)** → pesewas
+- **KES (Kenyan Shilling)** → cents
+
+```text
+major unit   → least denomination
+1 NGN        → 100 kobo
+1 GHS        → 100 pesewas
+1 KES        → 100 cents
+```
+
+## Example conversions
+
+```text
+100.00 NGN  → 10000  // kobo
+1,250.75 NGN → 125075 // kobo
+50.00 GHS   → 5000   // pesewas
+100.00 KES  → 10000  // cents
+```
+
+> 📘 Important
+> 
+> Always **convert on your side** before hitting our endpoints. The API does **not** accept decimal amounts.
+
+## Example: Collections request
+
+Below is an example request body for a collections endpoint where the customer is to be charged `1,250.75 NGN`.
+
+```json
+{
+  "customerId": "CUS_1234567890",
+  "currency": "NGN",
+  "amount": 125075,
+  "description": "Wallet funding via card"
+}
+```
+
+## Example: Disbursement request
+
+For a payout of `10,000.00 NGN` to a beneficiary account, the amount field becomes `1000000` (kobo):
+
+```json
+{
+  "beneficiaryId": "BEN_9876543210",
+  "currency": "NGN",
+  "amount": 1000000,
+  "narration": "Vendor settlement"
+}
+```
+
+## Common pitfalls
+
+- **Sending decimals**
+  - ❌ `"amount": 1250.75`
+  - ✅ `"amount": 125075`
+- **Mixing units**
+  - Don’t send some requests in naira and others in kobo.
+  - Always standardize to the smallest denomination in your integration layer.
+
+By always sending amounts in least denomination, your integrations with Payfonte collections and disbursement flows stay deterministic, predictable and aligned with our other endpoint specifications.

--- a/guides/introductions/amount-specification.mdx
+++ b/guides/introductions/amount-specification.mdx
@@ -16,12 +16,14 @@ For example, instead of sending `100.50` naira, you send `10050` kobo.
 
 Send **integer values only**, representing the amount in the currency’s smallest unit.
 
+- **XOF (Ivorian Franc)** → centimes
 - **NGN (Nigerian Naira)** → kobo
 - **GHS (Ghanaian Cedi)** → pesewas
 - **KES (Kenyan Shilling)** → cents
 
 ```text
 major unit   → least denomination
+1 XOF        → 100 centimes
 1 NGN        → 100 kobo
 1 GHS        → 100 pesewas
 1 KES        → 100 cents
@@ -30,6 +32,7 @@ major unit   → least denomination
 ## Example conversions
 
 ```text
+10.00 XOF  → 1000  //centimes
 100.00 NGN  → 10000  // kobo
 1,250.75 NGN → 125075 // kobo
 50.00 GHS   → 5000   // pesewas
@@ -46,7 +49,6 @@ Below is an example request body for a collections endpoint where the customer i
 
 ```json
 {
-  "customerId": "CUS_1234567890",
   "currency": "NGN",
   "amount": 125075,
   "description": "Wallet funding via card"
@@ -59,7 +61,7 @@ For a payout of `10,000.00 NGN` to a beneficiary account, the amount field becom
 
 ```json
 {
-  "beneficiaryId": "BEN_9876543210",
+  "transferRecipientId": "BEN_9876543210",
   "currency": "NGN",
   "amount": 1000000,
   "narration": "Vendor settlement"

--- a/guides/introductions/amount-specification.mdx
+++ b/guides/introductions/amount-specification.mdx
@@ -1,4 +1,7 @@
-# Amount Specification
+---
+title: Amount Specification
+---
+
 This page explains how to represent monetary values when interacting with Payfonte APIs. To keep calculations precise and consistent across currencies and providers, **all amounts must be sent in the smallest (least) denomination** of the currency.
 
 For example, instead of sending `100.50` naira, you send `10050` kobo.

--- a/snippets/snippet-intro.mdx
+++ b/snippets/snippet-intro.mdx
@@ -1,4 +1,0 @@
-One of the core principles of software development is DRY (Don't Repeat
-Yourself). This is a principle that apply to documentation as
-well. If you find yourself repeating the same content in multiple places, you
-should consider creating a custom snippet to keep your content in sync.


### PR DESCRIPTION
Desctiption: Added amount specification documentation with example that all amount should be in least denomination before sending it to payfonte API

Test Description: 
Clone Repo 
Run `Live Server`